### PR TITLE
Bugfix/filter unhandled popup events

### DIFF
--- a/src/WaxEventSource.ts
+++ b/src/WaxEventSource.ts
@@ -22,17 +22,16 @@ export class WaxEventSource {
     }
 
     const postTransaction = async (event: any) => {
-      if (event.data.type === "READY") {
-        // @ts-ignore
-        openedWindow.postMessage(message, this.waxSigningURL);
-      }
+      // @ts-ignore
+      openedWindow.postMessage(message, this.waxSigningURL);
     };
 
     const eventPromise = this.onceEvent(
       // @ts-ignore
       openedWindow,
       this.waxSigningURL,
-      postTransaction
+      postTransaction,
+      'READY'
     );
 
     await Promise.race([eventPromise, this.timeout()]).catch(err => {
@@ -49,7 +48,8 @@ export class WaxEventSource {
   public async onceEvent(
     source: Window,
     origin: string,
-    action: (e: any) => void
+    action: (e: any) => void,
+    type: string = null
   ) {
     return new Promise((resolve, reject) => {
       (window as Window).addEventListener(
@@ -66,6 +66,10 @@ export class WaxEventSource {
           }
 
           if (typeof event.data !== "object") {
+            return;
+          }
+
+          if (type != null && event.data.type !== type) {
             return;
           }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,28 +224,18 @@ export class WaxJS {
     return this.waxEventSource.onceEvent(
       confirmationWindow,
       this.waxSigningURL,
-      this.receiveSignatures.bind(this)
+      this.receiveSignatures.bind(this),
+      "TX_SIGNED"
     );
   }
 
   private async receiveSignatures(event: any) {
-    if (event.data.type === "TX_SIGNED") {
-      const { verified, signatures, whitelistedContracts } = event.data;
-      if (!verified || signatures == null) {
-        throw new Error("User declined to sign the transaction");
-      }
-      this.whitelistedContracts = whitelistedContracts || [];
-
-      return signatures;
-    } else if (event.data.type !== "READY") {
-      throw new Error(
-        `Unexpected response received when attempting signing: ${JSON.stringify(
-          event.data,
-          undefined,
-          2
-        )}`
-      );
+    const { verified, signatures, whitelistedContracts } = event.data;
+    if (!verified || signatures == null) {
+      throw new Error("User declined to sign the transaction");
     }
-    return [];
+    this.whitelistedContracts = whitelistedContracts || [];
+
+    return signatures;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,6 @@ export class WaxJS {
         return false;
       }
     }
-    return false;
   }
 
   private async loginViaWindow() {


### PR DESCRIPTION
This fixes a race in the signing popup that results in empty signatures.
Sometimes the `receiveSignatures` callback receives a `READY` event from the `WaxEventSource` when it can only handle `TX_SIGNED` events.